### PR TITLE
feat: add step function in utils that lets us track e2e progress

### DIFF
--- a/examples/selenium-interop/w3schools.test.ts
+++ b/examples/selenium-interop/w3schools.test.ts
@@ -1,7 +1,7 @@
 import { describe, test } from "@jest/globals";
 import { Builder, Browser, WebDriver } from "selenium-webdriver";
 import chrome from "selenium-webdriver/chrome.js";
-import { delay } from "@progress/roadkill/utils.js";
+import { sleep } from "@progress/roadkill/utils.js";
 import { Session, WebDriverClient } from "@progress/roadkill/webdriver.js";
 
 describe("w3schools", () => {
@@ -31,7 +31,7 @@ describe("w3schools", () => {
 
     test.skip("navigate to js statements page", async () => {
         await driver.navigate().to('http://www.w3schools.com');
-        await delay(3000);
+        await sleep(3000);
         await session.navigateTo('http://www.w3schools.com/js')
     }, 20000);
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2057,9 +2057,9 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.5",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
-            "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
+            "version": "29.5.6",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.6.tgz",
+            "integrity": "sha512-/t9NnzkOpXb4Nfvg17ieHE6EeSjDS2SGSpNYfoLbUAeL/EOueU/RSdOWFpfQTXBEM7BguYW1XQ0EbM+6RlIh6w==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -10094,6 +10094,7 @@
                 "roadkill": "roadkill.js"
             },
             "devDependencies": {
+                "@types/jest": "^29.5.6",
                 "@types/node": "^20.6.2",
                 "@types/plist": "^3.0.3",
                 "@types/yargs": "^17.0.25",

--- a/packages/@progress/roadkill/package.json
+++ b/packages/@progress/roadkill/package.json
@@ -3,7 +3,8 @@
     "type": "module",
     "version": "0.1.3",
     "scripts": {
-        "prepare": "tsc -p ."
+        "prepare": "tsc -p .",
+        "test": "node --experimental-vm-modules ../../../node_modules/jest/bin/jest.js --detectOpenHandles --forceExit"
     },
     "bin": {
         "roadkill": "./roadkill.js"
@@ -23,6 +24,7 @@
         "yargs": "^17.7.2"
     },
     "devDependencies": {
+        "@types/jest": "^29.5.6",
         "@types/node": "^20.6.2",
         "@types/plist": "^3.0.3",
         "@types/yargs": "^17.0.25",
@@ -52,5 +54,8 @@
         "server.ts",
         "server.js.map",
         "server.js"
-    ]
+    ],
+    "jest": {
+        "preset": "ts-jest/presets/default-esm"
+    }
 }

--- a/packages/@progress/roadkill/utils.test.ts
+++ b/packages/@progress/roadkill/utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, test, expect } from "@jest/globals";
+import { formatDuration } from "./utils.js";
+
+describe("utils", () => {
+    describe("formatDuration", () => {
+        test("0 ms.", () => expect(formatDuration(0)).toEqual("0 ms."));
+        test("9 ms.", () => expect(formatDuration(9)).toEqual("9 ms."));
+        test("12 ms.", () => expect(formatDuration(12)).toEqual("12 ms."));
+        test("1.000 sec.", () => expect(formatDuration(1000)).toEqual("1.000 sec."));
+        test("1.006 sec.", () => expect(formatDuration(1006)).toEqual("1.006 sec."));
+        test("1.015 sec.", () => expect(formatDuration(1015)).toEqual("1.015 sec."));
+        test("1.111 sec.", () => expect(formatDuration(1111)).toEqual("1.111 sec."));
+        test("1:00.000 min.", () => expect(formatDuration(60000)).toEqual("1:00 min."));
+        test("1:01.000 min.", () => expect(formatDuration(61000)).toEqual("1:01 min."));
+        test("1:01.020 min.", () => expect(formatDuration(61020)).toEqual("1:01 min."));
+        test("1:10.000 min.", () => expect(formatDuration(70000)).toEqual("1:10 min."));
+        test("1:10.123 min.", () => expect(formatDuration(70123)).toEqual("1:10 min."));
+    });
+});


### PR DESCRIPTION
This PR adds fancy "step" method in utils, that can wrap async calls and provides some progress feedback when the e2e tests executes. The log looks like this:
```
Test
  Run
    w3schools
      ○ w3schools > navigate to js statements page, at examples/jest-web/w3schools.test.ts:41:5
        ▪ navigate to https://www.w3schools.com/js (in 1.559 sec.)
        ▪ dismiss GDPR if any (in 36 ms.)
        ▪ find and click "JS Statements" (in 469 ms.)
        ▾ sleep 1 sec ...
        ⋮ sleep 1 sec (so far 10 sec.)
        ▪ sleep 1 sec (in 20 sec.)
        ▪ capture screenshot (in 284 ms.)
        ▾ save screenshot ...
          ▪ make dir recursive (in 1 ms.)
          ▪ write file (in 5 ms.)
        ▪ save screenshot (in 6 ms.)
      ✓ w3schools > navigate to js statements page (22 sec.)
```

With colours it is even prettier:
<img width="674" alt="Screenshot 2023-10-18 at 18 10 27" src="https://github.com/telerik/roadkill/assets/79846989/6f78bbca-af6b-4722-b20b-6decdea3af54">

Test code looks like:
```
    test("navigate to js statements page", async () => {
        await step("navigate to https://www.w3schools.com/js", () =>
            session.navigateTo("https://www.w3schools.com/js"));
        await step("dismiss GDPR if any", async () => {
            try {
                // If GDPR opens, accept all...
                const acceptAllCookies = await session.findElement(by.css(`#accept-choices`));
                await acceptAllCookies.click();
            } catch {}
        });
        await step(`find and click "JS Statements"`, async () => { 
            const statements = await session.findElement(by.xPath(`//a[text()="JS Statements"]`));
            await statements.click();
        });
```
