### PR TITLE
fix: bump version to 0.3.0 in package.json

### DIFF
--- a/packages/@progress/roadkill/package.json
+++ b/packages/@progress/roadkill/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@progress/roadkill",
     "type": "module",
-    "version": "0.2.4",
+    "version": "0.3.0",
     "scripts": {
         "prepare": "tsc -p ."
     },


### PR DESCRIPTION
Updated the package.json file to increase the version number from 0.2.4 to 0.3.0, preparing for the next release.